### PR TITLE
Rename generated code and stubs to Mutiny

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -97,7 +97,7 @@
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-grcp-protoc-plugin</artifactId>
                             <version>${project.version}</version>
-                            <mainClass>io.quarkus.grpc.protoc.plugin.QuarkusGrpcGenerator</mainClass>
+                            <mainClass>io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator</mainClass>
                         </protocPlugin>
                     </protocPlugins>
                 </configuration>

--- a/deployment/src/test/java/io/quarkus/grpc/server/GrpcServiceTestBase.java
+++ b/deployment/src/test/java/io/quarkus/grpc/server/GrpcServiceTestBase.java
@@ -8,9 +8,9 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
-import io.grpc.examples.helloworld.QuarkusGreeterGrpc;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
 import io.grpc.testing.integration.Messages;
-import io.grpc.testing.integration.QuarkusTestServiceGrpc;
+import io.grpc.testing.integration.MutinyTestServiceGrpc;
 import io.grpc.testing.integration.TestServiceGrpc;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -52,7 +52,7 @@ public class GrpcServiceTestBase {
 
     @Test
     public void testHelloWithMutinyClient() {
-        Uni<HelloReply> reply = QuarkusGreeterGrpc.newQuarkusStub(channel)
+        Uni<HelloReply> reply = MutinyGreeterGrpc.newMutinyStub(channel)
                 .sayHello(HelloRequest.newBuilder().setName("neo").build());
         assertThat(reply.await().indefinitely().getMessage()).isEqualTo("Hello neo");
     }
@@ -66,7 +66,7 @@ public class GrpcServiceTestBase {
 
     @Test
     public void testEmptyWithMutinyClient() {
-        EmptyProtos.Empty empty = QuarkusTestServiceGrpc.newQuarkusStub(channel)
+        EmptyProtos.Empty empty = MutinyTestServiceGrpc.newMutinyStub(channel)
                 .emptyCall(EmptyProtos.Empty.newBuilder().build()).await().indefinitely();
         assertThat(empty).isNotNull();
     }
@@ -80,7 +80,7 @@ public class GrpcServiceTestBase {
 
     @Test
     public void testUnaryMethodWithMutinyClient() {
-        Messages.SimpleResponse response = QuarkusTestServiceGrpc.newQuarkusStub(channel)
+        Messages.SimpleResponse response = MutinyTestServiceGrpc.newMutinyStub(channel)
                 .unaryCall(Messages.SimpleRequest.newBuilder().build()).await().indefinitely();
         assertThat(response).isNotNull();
     }
@@ -101,8 +101,8 @@ public class GrpcServiceTestBase {
 
     @Test
     public void testStreamingOutMethodWithMutinyClient() {
-        Multi<Messages.StreamingOutputCallResponse> multi = QuarkusTestServiceGrpc
-                .newQuarkusStub(channel)
+        Multi<Messages.StreamingOutputCallResponse> multi = MutinyTestServiceGrpc
+                .newMutinyStub(channel)
                 .streamingOutputCall(Messages.StreamingOutputCallRequest.newBuilder().build());
         assertThat(multi).isNotNull();
         List<String> list = multi.map(o -> o.getPayload().getBody().toStringUtf8()).collectItems().asList()
@@ -115,8 +115,8 @@ public class GrpcServiceTestBase {
         Multi<Messages.StreamingInputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
                 .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
                 .map(p -> Messages.StreamingInputCallRequest.newBuilder().setPayload(p).build());
-        Uni<Messages.StreamingInputCallResponse> done = QuarkusTestServiceGrpc
-                .newQuarkusStub(channel).streamingInputCall(input);
+        Uni<Messages.StreamingInputCallResponse> done = MutinyTestServiceGrpc
+                .newMutinyStub(channel).streamingInputCall(input);
         assertThat(done).isNotNull();
         done.await().indefinitely();
     }
@@ -126,8 +126,8 @@ public class GrpcServiceTestBase {
         Multi<Messages.StreamingOutputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
                 .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
                 .map(p -> Messages.StreamingOutputCallRequest.newBuilder().setPayload(p).build());
-        List<String> response = QuarkusTestServiceGrpc
-                .newQuarkusStub(channel).fullDuplexCall(input)
+        List<String> response = MutinyTestServiceGrpc
+                .newMutinyStub(channel).fullDuplexCall(input)
                 .map(o -> o.getPayload().getBody().toStringUtf8())
                 .collectItems().asList()
                 .await().indefinitely();
@@ -140,8 +140,8 @@ public class GrpcServiceTestBase {
         Multi<Messages.StreamingOutputCallRequest> input = Multi.createFrom().items("a", "b", "c", "d")
                 .map(s -> Messages.Payload.newBuilder().setBody(ByteString.copyFromUtf8(s)).build())
                 .map(p -> Messages.StreamingOutputCallRequest.newBuilder().setPayload(p).build());
-        List<String> response = QuarkusTestServiceGrpc
-                .newQuarkusStub(channel).halfDuplexCall(input)
+        List<String> response = MutinyTestServiceGrpc
+                .newMutinyStub(channel).halfDuplexCall(input)
                 .map(o -> o.getPayload().getBody().toStringUtf8())
                 .collectItems().asList()
                 .await().indefinitely();
@@ -160,7 +160,7 @@ public class GrpcServiceTestBase {
     @Test
     public void testUnimplementedMethodWithMutinyClient() {
         assertThatThrownBy(() ->
-                QuarkusTestServiceGrpc.newQuarkusStub(channel).unimplementedCall(EmptyProtos.Empty.newBuilder().build())
+                MutinyTestServiceGrpc.newMutinyStub(channel).unimplementedCall(EmptyProtos.Empty.newBuilder().build())
                         .await().indefinitely()
         ).isInstanceOf(StatusRuntimeException.class).hasMessageContaining("UNIMPLEMENTED");
     }

--- a/deployment/src/test/java/io/quarkus/grpc/server/MutinyGrpcServiceWithPlainTextTest.java
+++ b/deployment/src/test/java/io/quarkus/grpc/server/MutinyGrpcServiceWithPlainTextTest.java
@@ -6,9 +6,9 @@ import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloReplyOrBuilder;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.helloworld.HelloRequestOrBuilder;
-import io.grpc.examples.helloworld.QuarkusGreeterGrpc;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
 import io.grpc.testing.integration.Messages;
-import io.grpc.testing.integration.QuarkusTestServiceGrpc;
+import io.grpc.testing.integration.MutinyTestServiceGrpc;
 import io.grpc.testing.integration.TestServiceGrpc;
 import io.quarkus.grpc.server.services.MutinyHelloService;
 import io.quarkus.grpc.server.services.MutinyTestService;
@@ -27,9 +27,9 @@ public class MutinyGrpcServiceWithPlainTextTest extends GrpcServiceTestBase {
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(MutinyHelloService.class, MutinyTestService.class,
-                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, QuarkusGreeterGrpc.class,
+                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, MutinyGreeterGrpc.class,
                             HelloRequestOrBuilder.class, HelloReplyOrBuilder.class,
-                            EmptyProtos.class, Messages.class, QuarkusTestServiceGrpc.class,
+                            EmptyProtos.class, Messages.class, MutinyTestServiceGrpc.class,
                             TestServiceGrpc.class)
     );
 

--- a/deployment/src/test/java/io/quarkus/grpc/server/MutinyGrpcServiceWithSSLTest.java
+++ b/deployment/src/test/java/io/quarkus/grpc/server/MutinyGrpcServiceWithSSLTest.java
@@ -6,11 +6,11 @@ import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloReplyOrBuilder;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.helloworld.HelloRequestOrBuilder;
-import io.grpc.examples.helloworld.QuarkusGreeterGrpc;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.testing.integration.Messages;
-import io.grpc.testing.integration.QuarkusTestServiceGrpc;
+import io.grpc.testing.integration.MutinyTestServiceGrpc;
 import io.grpc.testing.integration.TestServiceGrpc;
 import io.netty.handler.ssl.SslContext;
 import io.quarkus.grpc.server.services.MutinyHelloService;
@@ -36,9 +36,9 @@ public class MutinyGrpcServiceWithSSLTest extends GrpcServiceTestBase {
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(MutinyHelloService.class, MutinyTestService.class,
-                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, QuarkusGreeterGrpc.class,
+                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, MutinyGreeterGrpc.class,
                             HelloRequestOrBuilder.class, HelloReplyOrBuilder.class,
-                            EmptyProtos.class, Messages.class, QuarkusTestServiceGrpc.class,
+                            EmptyProtos.class, Messages.class, MutinyTestServiceGrpc.class,
                             TestServiceGrpc.class))
             .withConfigurationResource("grpc-server-tls-configuration.properties");
 

--- a/deployment/src/test/java/io/quarkus/grpc/server/RegularGrpcServiceWithPlainTextTest.java
+++ b/deployment/src/test/java/io/quarkus/grpc/server/RegularGrpcServiceWithPlainTextTest.java
@@ -6,9 +6,9 @@ import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloReplyOrBuilder;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.helloworld.HelloRequestOrBuilder;
-import io.grpc.examples.helloworld.QuarkusGreeterGrpc;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
 import io.grpc.testing.integration.Messages;
-import io.grpc.testing.integration.QuarkusTestServiceGrpc;
+import io.grpc.testing.integration.MutinyTestServiceGrpc;
 import io.grpc.testing.integration.TestServiceGrpc;
 import io.quarkus.grpc.server.services.HelloService;
 import io.quarkus.grpc.server.services.TestService;
@@ -27,9 +27,9 @@ public class RegularGrpcServiceWithPlainTextTest extends GrpcServiceTestBase {
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(HelloService.class, TestService.class,
-                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, QuarkusGreeterGrpc.class,
+                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, MutinyGreeterGrpc.class,
                             HelloRequestOrBuilder.class, HelloReplyOrBuilder.class,
-                            EmptyProtos.class, Messages.class, QuarkusTestServiceGrpc.class,
+                            EmptyProtos.class, Messages.class, MutinyTestServiceGrpc.class,
                             TestServiceGrpc.class)
     );
 

--- a/deployment/src/test/java/io/quarkus/grpc/server/RegularGrpcServiceWithSSLTest.java
+++ b/deployment/src/test/java/io/quarkus/grpc/server/RegularGrpcServiceWithSSLTest.java
@@ -6,11 +6,11 @@ import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloReplyOrBuilder;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.helloworld.HelloRequestOrBuilder;
-import io.grpc.examples.helloworld.QuarkusGreeterGrpc;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.testing.integration.Messages;
-import io.grpc.testing.integration.QuarkusTestServiceGrpc;
+import io.grpc.testing.integration.MutinyTestServiceGrpc;
 import io.grpc.testing.integration.TestServiceGrpc;
 import io.netty.handler.ssl.SslContext;
 import io.quarkus.grpc.server.services.HelloService;
@@ -36,9 +36,9 @@ public class RegularGrpcServiceWithSSLTest extends GrpcServiceTestBase {
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(HelloService.class, TestService.class,
-                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, QuarkusGreeterGrpc.class,
+                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, MutinyGreeterGrpc.class,
                             HelloRequestOrBuilder.class, HelloReplyOrBuilder.class,
-                            EmptyProtos.class, Messages.class, QuarkusTestServiceGrpc.class,
+                            EmptyProtos.class, Messages.class, MutinyTestServiceGrpc.class,
                             TestServiceGrpc.class))
             .withConfigurationResource("grpc-server-tls-configuration.properties");
 

--- a/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorPriorityReversedTest.java
+++ b/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorPriorityReversedTest.java
@@ -7,7 +7,7 @@ import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloReplyOrBuilder;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.helloworld.HelloRequestOrBuilder;
-import io.grpc.examples.helloworld.QuarkusGreeterGrpc;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
 import io.quarkus.grpc.server.services.MutinyHelloService;
 import io.quarkus.test.QuarkusUnitTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -27,7 +27,7 @@ public class ServerInterceptorPriorityReversedTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(MutinyHelloService.class, MySecondInterceptor.class, MyFirstInterceptor.class,
-                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, QuarkusGreeterGrpc.class,
+                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, MutinyGreeterGrpc.class,
                             HelloRequestOrBuilder.class, HelloReplyOrBuilder.class));
 
     protected ManagedChannel channel;

--- a/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorPriorityTest.java
+++ b/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorPriorityTest.java
@@ -7,7 +7,7 @@ import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloReplyOrBuilder;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.helloworld.HelloRequestOrBuilder;
-import io.grpc.examples.helloworld.QuarkusGreeterGrpc;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
 import io.quarkus.grpc.server.services.MutinyHelloService;
 import io.quarkus.test.QuarkusUnitTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -27,7 +27,7 @@ public class ServerInterceptorPriorityTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(MutinyHelloService.class, MyFirstInterceptor.class, MySecondInterceptor.class,
-                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, QuarkusGreeterGrpc.class,
+                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, MutinyGreeterGrpc.class,
                             HelloRequestOrBuilder.class, HelloReplyOrBuilder.class));
 
     protected ManagedChannel channel;

--- a/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorRegistrationTest.java
+++ b/deployment/src/test/java/io/quarkus/grpc/server/interceptors/ServerInterceptorRegistrationTest.java
@@ -7,7 +7,7 @@ import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloReplyOrBuilder;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.helloworld.HelloRequestOrBuilder;
-import io.grpc.examples.helloworld.QuarkusGreeterGrpc;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
 import io.quarkus.grpc.server.services.MutinyHelloService;
 import io.quarkus.test.QuarkusUnitTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -27,7 +27,7 @@ public class ServerInterceptorRegistrationTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(MutinyHelloService.class, MyFirstInterceptor.class,
-                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, QuarkusGreeterGrpc.class,
+                            GreeterGrpc.class, HelloRequest.class, HelloReply.class, MutinyGreeterGrpc.class,
                             HelloRequestOrBuilder.class, HelloReplyOrBuilder.class));
 
     protected ManagedChannel channel;

--- a/deployment/src/test/java/io/quarkus/grpc/server/services/MutinyHelloService.java
+++ b/deployment/src/test/java/io/quarkus/grpc/server/services/MutinyHelloService.java
@@ -2,13 +2,13 @@ package io.quarkus.grpc.server.services;
 
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
-import io.grpc.examples.helloworld.QuarkusGreeterGrpc;
+import io.grpc.examples.helloworld.MutinyGreeterGrpc;
 import io.smallrye.mutiny.Uni;
 
 import javax.inject.Singleton;
 
 @Singleton
-public class MutinyHelloService extends QuarkusGreeterGrpc.GreeterImplBase {
+public class MutinyHelloService extends MutinyGreeterGrpc.GreeterImplBase {
 
     @Override
     public Uni<HelloReply> sayHello(HelloRequest request) {

--- a/deployment/src/test/java/io/quarkus/grpc/server/services/MutinyTestService.java
+++ b/deployment/src/test/java/io/quarkus/grpc/server/services/MutinyTestService.java
@@ -3,7 +3,7 @@ package io.quarkus.grpc.server.services;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.EmptyProtos;
 import io.grpc.testing.integration.Messages;
-import io.grpc.testing.integration.QuarkusTestServiceGrpc;
+import io.grpc.testing.integration.MutinyTestServiceGrpc;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Singleton
-public class MutinyTestService extends QuarkusTestServiceGrpc.TestServiceImplBase {
+public class MutinyTestService extends MutinyTestServiceGrpc.TestServiceImplBase {
 
     @Override
     public Uni<EmptyProtos.Empty> emptyCall(EmptyProtos.Empty request) {

--- a/examples/helloworld/pom.xml
+++ b/examples/helloworld/pom.xml
@@ -69,7 +69,7 @@
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-grcp-protoc-plugin</artifactId>
                             <version>${project.version}</version>
-                            <mainClass>io.quarkus.grpc.protoc.plugin.QuarkusGrpcGenerator</mainClass>
+                            <mainClass>io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator</mainClass>
                         </protocPlugin>
                     </protocPlugins>
                 </configuration>

--- a/examples/helloworld/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
+++ b/examples/helloworld/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
@@ -2,13 +2,13 @@ package io.quarkus.grpc.examples.hello;
 
 import examples.HelloReply;
 import examples.HelloRequest;
-import examples.QuarkusGreeterGrpc;
+import examples.MutinyGreeterGrpc;
 import io.smallrye.mutiny.Uni;
 
 import javax.inject.Singleton;
 
 @Singleton
-public class HelloWorldService extends QuarkusGreeterGrpc.GreeterImplBase {
+public class HelloWorldService extends MutinyGreeterGrpc.GreeterImplBase {
 
     @Override
     public Uni<HelloReply> sayHello(HelloRequest request) {

--- a/examples/helloworld/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldServiceTest.java
+++ b/examples/helloworld/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldServiceTest.java
@@ -3,7 +3,7 @@ package io.quarkus.grpc.examples.hello;
 import examples.GreeterGrpc;
 import examples.HelloReply;
 import examples.HelloRequest;
-import examples.QuarkusGreeterGrpc;
+import examples.MutinyGreeterGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.quarkus.test.junit.QuarkusTest;
@@ -25,7 +25,7 @@ class HelloWorldServiceTest {
     @Test
     public void testHelloWorldServiceUsingMutinyStub() {
         ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", 9000).usePlaintext().build();
-        HelloReply reply = QuarkusGreeterGrpc.newQuarkusStub(channel)
+        HelloReply reply = MutinyGreeterGrpc.newMutinyStub(channel)
                 .sayHello(HelloRequest.newBuilder().setName("neo-blocking").build()).await().indefinitely();
         assertThat(reply.getMessage()).isEqualTo("Hello neo-blocking");
     }

--- a/examples/streaming/pom.xml
+++ b/examples/streaming/pom.xml
@@ -61,7 +61,7 @@
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-grcp-protoc-plugin</artifactId>
                             <version>${project.version}</version>
-                            <mainClass>io.quarkus.grpc.protoc.plugin.QuarkusGrpcGenerator</mainClass>
+                            <mainClass>io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator</mainClass>
                         </protocPlugin>
                     </protocPlugins>
                 </configuration>

--- a/examples/streaming/src/main/java/io/quarkus/grpc/example/streaming/StreamingService.java
+++ b/examples/streaming/src/main/java/io/quarkus/grpc/example/streaming/StreamingService.java
@@ -2,7 +2,7 @@ package io.quarkus.grpc.example.streaming;
 
 import io.grpc.examples.streaming.Empty;
 import io.grpc.examples.streaming.Item;
-import io.grpc.examples.streaming.QuarkusStreamingGrpc;
+import io.grpc.examples.streaming.MutinyStreamingGrpc;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
@@ -10,7 +10,7 @@ import javax.inject.Singleton;
 import java.time.Duration;
 
 @Singleton
-public class StreamingService extends QuarkusStreamingGrpc.StreamingImplBase {
+public class StreamingService extends MutinyStreamingGrpc.StreamingImplBase {
 
     @Override
     public Multi<Item> source(Empty request) {

--- a/examples/streaming/src/test/java/io/quarkus/grpc/example/streaming/StreamingServiceTest.java
+++ b/examples/streaming/src/test/java/io/quarkus/grpc/example/streaming/StreamingServiceTest.java
@@ -4,7 +4,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.examples.streaming.Empty;
 import io.grpc.examples.streaming.Item;
-import io.grpc.examples.streaming.QuarkusStreamingGrpc;
+import io.grpc.examples.streaming.MutinyStreamingGrpc;
 import io.grpc.examples.streaming.StreamingGrpc;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.mutiny.Multi;
@@ -45,14 +45,14 @@ public class StreamingServiceTest {
 
     @Test
     public void testSourceWithMutinyStub() {
-        Multi<Item> source = QuarkusStreamingGrpc.newQuarkusStub(channel).source(Empty.newBuilder().build());
+        Multi<Item> source = MutinyStreamingGrpc.newMutinyStub(channel).source(Empty.newBuilder().build());
         List<String> list = source.map(Item::getValue).collectItems().asList().await().indefinitely();
         assertThat(list).containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
     }
 
     @Test
     public void testSinkWithMutinyStub() {
-        Uni<Empty> done = QuarkusStreamingGrpc.newQuarkusStub(channel)
+        Uni<Empty> done = MutinyStreamingGrpc.newMutinyStub(channel)
                 .sink(Multi.createFrom().ticks().every(Duration.ofMillis(2))
                         .transform().byTakingFirstItems(5)
                         .map(l -> Item.newBuilder().setValue(l.toString()).build()));
@@ -64,7 +64,7 @@ public class StreamingServiceTest {
         Multi<Item> source = Multi.createFrom().ticks().every(Duration.ofMillis(2))
                 .transform().byTakingFirstItems(5)
                 .map(l -> Item.newBuilder().setValue(l.toString()).build());
-        Multi<Item> results = QuarkusStreamingGrpc.newQuarkusStub(channel).pipe(source);
+        Multi<Item> results = MutinyStreamingGrpc.newMutinyStub(channel).pipe(source);
 
         List<Long> items = results
                 .map(i -> Long.parseLong(i.getValue()))

--- a/protoc/src/main/java/io/quarkus/grpc/protoc/plugin/MutinyGrpcGenerator.java
+++ b/protoc/src/main/java/io/quarkus/grpc/protoc/plugin/MutinyGrpcGenerator.java
@@ -17,11 +17,11 @@ import java.util.stream.Collectors;
 /**
  * @author Paulo Lopes
  */
-public class QuarkusGrpcGenerator extends Generator {
+public class MutinyGrpcGenerator extends Generator {
 
     private static final int SERVICE_NUMBER_OF_PATHS = 2;
     private static final int METHOD_NUMBER_OF_PATHS = 4;
-    private static final String CLASS_PREFIX = "Quarkus";
+    private static final String CLASS_PREFIX = "Mutiny";
 
     private String getServiceJavaDocPrefix() {
         return "    ";
@@ -77,6 +77,7 @@ public class QuarkusGrpcGenerator extends Generator {
 
     private ServiceContext buildServiceContext(DescriptorProtos.ServiceDescriptorProto serviceProto, ProtoTypeMap typeMap, List<DescriptorProtos.SourceCodeInfo.Location> locations, int serviceNumber) {
         ServiceContext serviceContext = new ServiceContext();
+        serviceContext.classPrefix = CLASS_PREFIX;
         serviceContext.fileName = CLASS_PREFIX + serviceProto.getName() + "Grpc.java";
         serviceContext.className = CLASS_PREFIX + serviceProto.getName() + "Grpc";
         serviceContext.serviceName = serviceProto.getName();
@@ -129,19 +130,19 @@ public class QuarkusGrpcGenerator extends Generator {
         methodContext.javaDoc = getJavaDoc(getComments(methodLocation), getMethodJavaDocPrefix());
 
         if (!methodProto.getClientStreaming() && !methodProto.getServerStreaming()) {
-            methodContext.quarkusCallsMethodName = "oneToOne";
+            methodContext.mutinyCallsMethodName = "oneToOne";
             methodContext.grpcCallsMethodName = "asyncUnaryCall";
         }
         if (!methodProto.getClientStreaming() && methodProto.getServerStreaming()) {
-            methodContext.quarkusCallsMethodName = "oneToMany";
+            methodContext.mutinyCallsMethodName = "oneToMany";
             methodContext.grpcCallsMethodName = "asyncServerStreamingCall";
         }
         if (methodProto.getClientStreaming() && !methodProto.getServerStreaming()) {
-            methodContext.quarkusCallsMethodName = "manyToOne";
+            methodContext.mutinyCallsMethodName = "manyToOne";
             methodContext.grpcCallsMethodName = "asyncClientStreamingCall";
         }
         if (methodProto.getClientStreaming() && methodProto.getServerStreaming()) {
-            methodContext.quarkusCallsMethodName = "manyToMany";
+            methodContext.mutinyCallsMethodName = "manyToMany";
             methodContext.grpcCallsMethodName = "asyncBidiStreamingCall";
         }
         return methodContext;
@@ -158,7 +159,7 @@ public class QuarkusGrpcGenerator extends Generator {
     }
 
     private PluginProtos.CodeGeneratorResponse.File buildFile(ServiceContext context) {
-        String content = applyTemplate("QuarkusStub.mustache", context);
+        String content = applyTemplate("MutinyStub.mustache", context);
         return PluginProtos.CodeGeneratorResponse.File
                 .newBuilder()
                 .setName(absoluteFileName(context))
@@ -197,12 +198,13 @@ public class QuarkusGrpcGenerator extends Generator {
     /**
      * Template class for proto Service objects.
      */
-    private class ServiceContext {
+    private static class ServiceContext {
         // CHECKSTYLE DISABLE VisibilityModifier FOR 8 LINES
         public String fileName;
         public String protoName;
         public String packageName;
         public String className;
+        public String classPrefix;
         public String serviceName;
         public boolean deprecated;
         public String javaDoc;
@@ -228,7 +230,7 @@ public class QuarkusGrpcGenerator extends Generator {
     /**
      * Template class for proto RPC objects.
      */
-    private class MethodContext {
+    private static class MethodContext {
         // CHECKSTYLE DISABLE VisibilityModifier FOR 10 LINES
         public String methodName;
         public String inputType;
@@ -236,7 +238,7 @@ public class QuarkusGrpcGenerator extends Generator {
         public boolean deprecated;
         public boolean isManyInput;
         public boolean isManyOutput;
-        public String quarkusCallsMethodName;
+        public String mutinyCallsMethodName;
         public String grpcCallsMethodName;
         public int methodNumber;
         public String javaDoc;
@@ -281,9 +283,9 @@ public class QuarkusGrpcGenerator extends Generator {
 
     public static void main(String[] args) {
         if (args.length == 0) {
-            ProtocPlugin.generate(new QuarkusGrpcGenerator());
+            ProtocPlugin.generate(new MutinyGrpcGenerator());
         } else {
-            ProtocPlugin.debug(new QuarkusGrpcGenerator(), args[0]);
+            ProtocPlugin.debug(new MutinyGrpcGenerator(), args[0]);
         }
     }
 }

--- a/protoc/src/main/resources/MutinyStub.mustache
+++ b/protoc/src/main/resources/MutinyStub.mustache
@@ -13,59 +13,59 @@ import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 @java.lang.Deprecated
 {{/deprecated}}
 @javax.annotation.Generated(
-value = "by QuarkusGrpc generator",
+value = "by {{classPrefix}} Grpc generator",
 comments = "Source: {{protoName}}")
 public final class {{className}} {
     private {{className}}() {}
 
-    public static Quarkus{{serviceName}}Stub newQuarkusStub(io.grpc.Channel channel) {
-        return new Quarkus{{serviceName}}Stub(channel);
+    public static {{classPrefix}}{{serviceName}}Stub new{{classPrefix}}Stub(io.grpc.Channel channel) {
+        return new {{classPrefix}}{{serviceName}}Stub(channel);
     }
 
     {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
-    public static final class Quarkus{{serviceName}}Stub extends io.grpc.stub.AbstractStub<Quarkus{{serviceName}}Stub> {
+    public static final class {{classPrefix}}{{serviceName}}Stub extends io.grpc.stub.AbstractStub<{{classPrefix}}{{serviceName}}Stub> {
         private {{serviceName}}Grpc.{{serviceName}}Stub delegateStub;
 
-        private Quarkus{{serviceName}}Stub(io.grpc.Channel channel) {
+        private {{classPrefix}}{{serviceName}}Stub(io.grpc.Channel channel) {
             super(channel);
             delegateStub = {{serviceName}}Grpc.newStub(channel);
         }
 
-        private Quarkus{{serviceName}}Stub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+        private {{classPrefix}}{{serviceName}}Stub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
             super(channel, callOptions);
             delegateStub = {{serviceName}}Grpc.newStub(channel).build(channel, callOptions);
         }
 
         @Override
-        protected Quarkus{{serviceName}}Stub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-            return new Quarkus{{serviceName}}Stub(channel, callOptions);
+        protected {{classPrefix}}{{serviceName}}Stub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new {{classPrefix}}{{serviceName}}Stub(channel, callOptions);
         }
 
         {{#unaryUnaryMethods}}
         {{{methodHeader}}}
         public io.smallrye.mutiny.Uni<{{outputType}}> {{methodName}}({{inputType}} request) {
-            return io.quarkus.grpc.runtime.ClientCalls.{{quarkusCallsMethodName}}(request, delegateStub::{{methodName}});
+            return io.quarkus.grpc.runtime.ClientCalls.{{mutinyCallsMethodName}}(request, delegateStub::{{methodName}});
         }
 
         {{/unaryUnaryMethods}}
         {{#unaryManyMethods}}
         {{{methodHeader}}}
         public io.smallrye.mutiny.Multi<{{outputType}}> {{methodName}}({{inputType}} request) {
-            return io.quarkus.grpc.runtime.ClientCalls.{{quarkusCallsMethodName}}(request, delegateStub::{{methodName}});
+            return io.quarkus.grpc.runtime.ClientCalls.{{mutinyCallsMethodName}}(request, delegateStub::{{methodName}});
         }
 
         {{/unaryManyMethods}}
         {{#manyUnaryMethods}}
         {{{methodHeader}}}
         public io.smallrye.mutiny.Uni<{{outputType}}> {{methodName}}(io.smallrye.mutiny.Multi<{{inputType}}> hdlr) {
-            return io.quarkus.grpc.runtime.ClientCalls.{{quarkusCallsMethodName}}(hdlr, delegateStub::{{methodName}});
+            return io.quarkus.grpc.runtime.ClientCalls.{{mutinyCallsMethodName}}(hdlr, delegateStub::{{methodName}});
         }
 
         {{/manyUnaryMethods}}
         {{#manyManyMethods}}
         {{{methodHeader}}}
         public io.smallrye.mutiny.Multi<{{outputType}}> {{methodName}}(io.smallrye.mutiny.Multi<{{inputType}}> hdlr) {
-            return io.quarkus.grpc.runtime.ClientCalls.{{quarkusCallsMethodName}}(hdlr, delegateStub::{{methodName}});
+            return io.quarkus.grpc.runtime.ClientCalls.{{mutinyCallsMethodName}}(hdlr, delegateStub::{{methodName}});
         }
         {{/manyManyMethods}}
     }
@@ -141,7 +141,7 @@ public final class {{className}} {
                 {{#methods}}
                 {{^isManyInput}}
                 case METHODID_{{methodNameUpperUnderscore}}:
-                    io.quarkus.grpc.runtime.ServerCalls.{{quarkusCallsMethodName}}(({{inputType}}) request,
+                    io.quarkus.grpc.runtime.ServerCalls.{{mutinyCallsMethodName}}(({{inputType}}) request,
                             (io.grpc.stub.StreamObserver<{{outputType}}>) responseObserver,
                             serviceImpl::{{methodName}});
                     break;
@@ -159,7 +159,7 @@ public final class {{className}} {
                 {{#methods}}
                 {{#isManyInput}}
                 case METHODID_{{methodNameUpperUnderscore}}:
-                    return (io.grpc.stub.StreamObserver<Req>) io.quarkus.grpc.runtime.ServerCalls.{{quarkusCallsMethodName}}(
+                    return (io.grpc.stub.StreamObserver<Req>) io.quarkus.grpc.runtime.ServerCalls.{{mutinyCallsMethodName}}(
                             (io.grpc.stub.StreamObserver<{{outputType}}>) responseObserver,
                             serviceImpl::{{methodName}});
                 {{/isManyInput}}


### PR DESCRIPTION
Fixes #30 

This PR will rename the generated class from `Quarkus`XYZ to `Mutiny`XYZ, plus the stub constructor from `newQuarkusStub()` to `newMutinyStub()`.

The Prefix is now a variable and used in the template instead of the hard coded value.