### PR TITLE
CI - native tests, quarkus master and last release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,8 @@ on:
       - master
 
 jobs:
-  build:
-    runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [8, 11]
+  build_java8_quarkus_master:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1
@@ -30,14 +26,58 @@ jobs:
             git grep import | grep '\*;' | grep -E -v '(.mvn/|README.md|CONTRIBUTING.md)'
             exit 1
           fi
-      - name: Install JDK ${{ matrix.java }}
+      - name: Install JDK 1.8
         uses: joschi/setup-jdk@v1.0.0
         with:
-          java-version: openjdk${{ matrix.java }}
+          java-version: 'openjdk8'
+      - name: Build Quarkus master
+          run: |
+            git clone https://github.com/quarkusio/quarkus.git \
+            && cd quarkus \
+            && mvn -B clean install -DskipTests -DskipITs -DskipDocs
+            - name: Build with Maven
+              run: export LANG=en_US && mvn -B clean install
+      - name: Build with Maven
+        run: mvn -B clean install --file pom.xml
+
+  build_java11_quarkus_master:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Install JDK 11
+        uses: joschi/setup-jdk@v1.0.0
+        with:
+          java-version: 'openjdk11'
       - name: Build Quarkus master
         run: |
           git clone https://github.com/quarkusio/quarkus.git \
-            && cd quarkus \
-            && mvn -B clean install -DskipTests -DskipITs -DskipDocs
+          && cd quarkus \
+          && mvn -B clean install -DskipTests -DskipITs -DskipDocs
       - name: Build with Maven
-        run: export LANG=en_US && mvn -B clean install
+        run: export LANG=en_US && mvn -B clean install -Pnative -Dquarkus.native.container-build=true
+
+  build_java11_quarkus_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Install JDK 11
+        uses: joschi/setup-jdk@v1.0.0
+        with:
+          java-version: 'openjdk11'
+      - name: Update Quarkus version
+        run: |
+          mvn versions:set-property -Dproperty="quarkus.version" -DnewVersion="1.3.2.Final" -DgenerateBackupPoms=false
+      - name: Build with Maven
+        run: export LANG=en_US && mvn -B clean install -Pnative -Dquarkus.native.container-build=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: "Build - master and PR"
 
 on:
+  schedule: # nightly build
+    - cron: '0 2 * * *'
   push:
     branches:
       - master
@@ -31,12 +33,10 @@ jobs:
         with:
           java-version: 'openjdk8'
       - name: Build Quarkus master
-          run: |
+        run: |
             git clone https://github.com/quarkusio/quarkus.git \
             && cd quarkus \
             && mvn -B clean install -DskipTests -DskipITs -DskipDocs
-            - name: Build with Maven
-              run: export LANG=en_US && mvn -B clean install
       - name: Build with Maven
         run: mvn -B clean install --file pom.xml
 


### PR DESCRIPTION
Fix #31

* Test both Quarkus master (default, java 8 and java 11) and last release (Java 11 only)
* Enable native for Java 11
* Enable nightly build