### PR TITLE
Improve shutdown logic

### DIFF
--- a/deployment/src/test/java/io/quarkus/grpc/client/InstanceInjectionTest.java
+++ b/deployment/src/test/java/io/quarkus/grpc/client/InstanceInjectionTest.java
@@ -8,14 +8,12 @@ import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.helloworld.HelloRequestOrBuilder;
 import io.grpc.examples.helloworld.MutinyGreeterGrpc;
 import io.quarkus.grpc.runtime.annotations.GrpcService;
-import io.quarkus.grpc.server.services.HelloService;
 import io.quarkus.test.QuarkusUnitTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
@@ -27,8 +25,8 @@ public class InstanceInjectionTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(GreeterGrpc.class, GreeterGrpc.GreeterBlockingStub.class,
-                            MutinyGreeterGrpc.MutinyGreeterStub.class,
-                            HelloService.class, HelloRequest.class, HelloReply.class,
+                            MutinyGreeterGrpc.MutinyGreeterStub.class, MutinyGreeterGrpc.class,
+                            HelloRequest.class, HelloReply.class,
                             HelloReplyOrBuilder.class, HelloRequestOrBuilder.class))
             .withConfigurationResource("hello-config.properties");
 
@@ -43,6 +41,10 @@ public class InstanceInjectionTest {
         assertThat(channel.isUnsatisfied()).isFalse();
         assertThat(blocking.isUnsatisfied()).isFalse();
         assertThat(mutiny.isUnsatisfied()).isFalse();
+
+        assertThat(channel.get()).isNotNull();
+        assertThat(blocking.get()).isNotNull();
+        assertThat(mutiny.get()).isNotNull();
     }
 
 }

--- a/examples/helloworld/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldEndpointTest.java
+++ b/examples/helloworld/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldEndpointTest.java
@@ -1,13 +1,6 @@
 package io.quarkus.grpc.examples.hello;
 
-import examples.GreeterGrpc;
-import examples.HelloReply;
-import examples.HelloRequest;
-import examples.MutinyGreeterGrpc;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.get;
@@ -27,6 +20,5 @@ class HelloWorldEndpointTest {
         String response = get("/hello/mutiny/neo-mutiny").asString();
         assertThat(response).startsWith("Hello neo-mutiny");
     }
-
 
 }

--- a/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerBean.java
+++ b/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerBean.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -104,19 +103,18 @@ public class GrpcServerBean {
         shutdown.addLastShutdownTask(() -> {
                     if (server != null) {
                         LOGGER.info("Stopping GRPC server");
-                        CountDownLatch latch = new CountDownLatch(1);
                         server.shutdown(ar -> {
                             if (ar.failed()) {
                                 LOGGER.errorf(ar.cause(), "Unable to stop the GRPC server gracefully");
                             }
-                            latch.countDown();
                         });
 
                         try {
-                            latch.await(10, TimeUnit.SECONDS);
+                            server.awaitTermination(10, TimeUnit.SECONDS);
+                            LOGGER.debug("GRPC Server stopped");
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
-                            LOGGER.error("Unable to stop the GRPC server gracefully after 10 seconds");
+                            LOGGER.error("Unable to stop the GRPC server gracefully");
                         }
 
                         server = null;


### PR DESCRIPTION
Rewrite server shutdown logic
Fix #39 - Explicit shutdown of the channel in test
Fix #40 - Avoid starting the server in the instance injection test