### PR TITLE
Remove the workaround required for ALPN when using Java 1.8.252.

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -87,7 +87,6 @@
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemProperties>
-                    <argLine>${jetty.alpnAgent.argLine}</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -139,20 +138,10 @@
             <activation>
                 <jdk>1.8</jdk>
             </activation>
-            <properties>
-                <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
-                <jetty.alpnAgent.argLine>-javaagent:"${jetty.alpnAgent.path}"</jetty.alpnAgent.argLine>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.mortbay.jetty.alpn</groupId>
-                    <artifactId>jetty-alpn-agent</artifactId>
-                    <version>${jetty.alpnAgent.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/examples/helloworld-mutual-tls/pom.xml
+++ b/examples/helloworld-mutual-tls/pom.xml
@@ -114,7 +114,6 @@
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemProperties>
-                    <argLine>${jetty.alpnAgent.argLine}</argLine>
                 </configuration>
             </plugin>
         </plugins>
@@ -126,20 +125,10 @@
             <activation>
                 <jdk>1.8</jdk>
             </activation>
-            <properties>
-                <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
-                <jetty.alpnAgent.argLine>-javaagent:"${jetty.alpnAgent.path}"</jetty.alpnAgent.argLine>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.mortbay.jetty.alpn</groupId>
-                    <artifactId>jetty-alpn-agent</artifactId>
-                    <version>${jetty.alpnAgent.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/examples/helloworld-tls/pom.xml
+++ b/examples/helloworld-tls/pom.xml
@@ -114,7 +114,6 @@
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemProperties>
-                    <argLine>${jetty.alpnAgent.argLine}</argLine>
                 </configuration>
             </plugin>
         </plugins>
@@ -126,20 +125,10 @@
             <activation>
                 <jdk>1.8</jdk>
             </activation>
-            <properties>
-                <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
-                <jetty.alpnAgent.argLine>-javaagent:"${jetty.alpnAgent.path}"</jetty.alpnAgent.argLine>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.mortbay.jetty.alpn</groupId>
-                    <artifactId>jetty-alpn-agent</artifactId>
-                    <version>${jetty.alpnAgent.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,6 @@
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <junit-api.version>5.6.1</junit-api.version>
-        <jetty.alpnAgent.version>2.0.9</jetty.alpnAgent.version>
-
-        <!-- use on Java 8 to use the Jetty ALPN Provider -->
-        <jetty.alpnAgent.argLine></jetty.alpnAgent.argLine>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Revert "Explicit usage of the Jetty Agent to provide ALPN until Netty detection is fixed."

This reverts commit fb3e45e9aaaff39cfc761de588c3bc4f39b81a7d.